### PR TITLE
Fix: Issue/5 포스트 - 태그 관계 수정

### DIFF
--- a/src/main/java/com/example/boardserver/dto/PostDTO.java
+++ b/src/main/java/com/example/boardserver/dto/PostDTO.java
@@ -24,3 +24,7 @@ public class PostDTO {
     private Date updateTime;
     private List<TagDTO> tags;
 }
+/**
+ * comment 와는 1:n
+ * tag 와는 M:N
+ */

--- a/src/main/java/com/example/boardserver/mapper/TagMapper.java
+++ b/src/main/java/com/example/boardserver/mapper/TagMapper.java
@@ -12,6 +12,6 @@ public interface TagMapper {
 
     public void deletePostTag(int postId);
 
-    //태그와 게시글의 n:n 관계를 표시하기 위한 post tag table 에 정보를 저장하기 위함
+    //태그와 게시글의 m:n 관계를 표시하기 위한 post tag table 에 정보를 저장하기 위함
     public void createPostTag(Integer tagId, Integer postId); //Integer?
 }

--- a/src/main/java/com/example/boardserver/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/example/boardserver/service/impl/PostServiceImpl.java
@@ -38,16 +38,20 @@ public class PostServiceImpl implements PostService {
             postMapper.register(postDTO);
             int postId = postDTO.getId();
             // 생성됨 post 객체에서 태크 리스트 생성
-            for(int i=0; i<postDTO.getTags().size(); i++){
-                log.info("postID::::{}",postId );
+            for (int i = 0; i < postDTO.getTags().size(); i++) {
+                log.info("postID::::{}", postId);
+
                 TagDTO tagDTO = postDTO.getTags().get(i);
-
-                tagDTO.setPostId(postId); //임의로 추가
-
+                // 태그가 아직 등록되지 않았으므로, 먼저 태그를 등록
                 tagMapper.register(tagDTO);
-                Integer tagId = tagDTO.getId();
-                // M:N 관계 테이블 생성
+
+                // 태그가 등록되었으므로 이제 tag_id를 얻을 수 있음
+                int tagId = tagDTO.getId();
+                log.info("tagID::::{}", tagId);
+
+                // M:N 관계에서 post와 tag를 연결
                 tagMapper.createPostTag(tagId, postId);
+
             }
 
         } else {

--- a/src/main/resources/mappers/tagMapper.xml
+++ b/src/main/resources/mappers/tagMapper.xml
@@ -5,11 +5,9 @@
 <mapper namespace="com.example.boardserver.mapper.TagMapper">
 
   <insert id="register" parameterType="com.example.boardserver.dto.TagDTO">
-    INSERT INTO tag (post_id,
-                     name,
+    INSERT INTO tag (name,
                      url)
-    VALUES (#{postId},
-            #{name},
+    VALUES (#{name},
             #{url})
     <selectKey keyProperty="id" resultType="int">
       SELECT LAST_INSERT_ID()


### PR DESCRIPTION
- post_tag table 에 post_id, tag_id가 들어가지 않았던 문제 해결.
- post_tag 는 post와 tag의 m:n 관계를 표현하는 테이블. 
- tag table 가 post_id 를 가지고 있어 SQL 에러가 났던 것. 삭제 후 진행